### PR TITLE
Fix parsing of 'service_type'

### DIFF
--- a/ipfs_utils.py
+++ b/ipfs_utils.py
@@ -13,7 +13,7 @@ class IPFSPinner:
         api_key : str
             the API key for the service (not needed for "ipfs")
         api_secret : str
-            the API secrete for the service (not needed for "ipfs")        
+            the API secrete for the service (not needed for "ipfs")
         """
         self.api_key = api_key
         self.api_secret = api_secret
@@ -54,9 +54,9 @@ class IPFSPinner:
             self.pinIpfsLocalNode(ipfs_hash, name, type_data)
         elif self.ipfs_service_type == 'infura':
             raise Exception('Infura not implemented yet.')
-        else: 
+        else:
             raise Exception('Unknown IPFS service type')
-        
+
     def pinataRequest(self, ipfs_hash,name,type_data):
         url_pin = "https://api.pinata.cloud/pinning/pinByHash"
         headers = {
@@ -80,5 +80,5 @@ class IPFSPinner:
         result = subprocess.call(["ipfs", "pin", "add", ipfs_hash])
         if result == 0:
             print(f'{type_data} pinned')
-        else: 
+        else:
             print(f'Error pinning IPFS hash. Error code {result}')

--- a/pin_collection.py
+++ b/pin_collection.py
@@ -13,7 +13,7 @@ def main(argv):
     service_type = 'pinata'
 
     try:
-        opts, args = getopt.getopt(argv, "w:k:s:t:",["wallet=","api_key=","api_secret=","service_type"])
+        opts, args = getopt.getopt(argv, "w:k:s:t:",["wallet=","api_key=","api_secret=","service_type="])
 
     except:
         print("Error in arguments: pin_collection.py --wallet <wallet> --api_key <api_key> --api_secret <api_secret> --service_type [pinata|ipfs|infura]")

--- a/pin_creations.py
+++ b/pin_creations.py
@@ -13,7 +13,7 @@ def main(argv):
     service_type = 'pinata'
 
     try:
-        opts, args = getopt.getopt(argv, "w:k:s:t:",["wallet=","api_key=","api_secret=","service_type"])
+        opts, args = getopt.getopt(argv, "w:k:s:t:",["wallet=","api_key=","api_secret=","service_type="])
 
     except:
         print("Error in arguments: pin_creations.py --wallet <wallet> --api_key <api_key> --api_secret <api_secret> --service_type [pinata|ipfs|infura]")

--- a/pin_tokens.py
+++ b/pin_tokens.py
@@ -25,7 +25,7 @@ def main(argv):
     service_type = 'pinata'
 
     try:
-        opts, args = getopt.getopt(argv, "i:k:s:t:",["id=","api_key=","api_secret=","service_type"])
+        opts, args = getopt.getopt(argv, "i:k:s:t:",["id=","api_key=","api_secret=","service_type="])
 
     except:
         print("Error in arguments: pin_tokens.py --id <GT_token> --api_key <api_key> --api_secret <api_secret> --service_type [pinata|ipfs|infura]")


### PR DESCRIPTION
Add a missing '=' to the getopt arguments to fix parsing of 'service_type'.

I have to add that I'm not a python person, but this seems to have fixed the problem and allowed me to use my local ipfs node to back up my content. Please let me know if you have any comments or concerns.

Thanks!